### PR TITLE
Fix issue with download-all-images on Windows

### DIFF
--- a/download-all-images/main.py
+++ b/download-all-images/main.py
@@ -31,7 +31,7 @@ if not exists(images_dir_path):
     makedirs(images_dir_path)
 
 path = Path(__file__).parent / "../csvs/card.csv"
-with path.open(newline='') as csvfile:
+with path.open(newline='', encoding='utf-8') as csvfile:
     reader = csv.reader(csvfile, delimiter='\t', quotechar='"')
     next(reader)
 


### PR DESCRIPTION
https://github.com/the-fab-cube/flesh-and-blood-cards/issues/154

Aims to resolve usage of the `download-all-images` script on Windows by forcing UTF-8 encoding.

Not sure if this plays nicely with other OS, so please check that out!