### PR TITLE
Add 'Angel' to type.csv

### DIFF
--- a/csvs/type.csv
+++ b/csvs/type.csv
@@ -3,6 +3,7 @@ Action
 Adjudicator
 Affliction
 Ally
+Angel
 Arms
 Arrow
 Ash


### PR DESCRIPTION
This card type is referenced by an object in card.csv but is not present in type.csv. This patch adds it to type.csv to ensure that references between tables are present and correct.

Resolves #192