### PR TITLE
Fix incorrect rules text for Bloodspill Invocation

### DIFF
--- a/csvs/card.csv
+++ b/csvs/card.csv
@@ -830,14 +830,14 @@ When your hero is dealt damage, destroy Bloodspill Invocation."		Runeblade Actio
 
 **Go again**
 
-When an attack action card you control hits, destroy Bloodspill Invocation then create 3 Runechant tokens. *(They're auras with ""When you play an attack action card or attack with a weapon, destroy Runechant and deal 1 arcane damage to target opposing hero."")*
+When an attack action card you control hits, destroy Bloodspill Invocation then create 2 Runechant tokens. *(They're auras with ""When you play an attack action card or attack with a weapon, destroy Runechant and deal 1 arcane damage to target opposing hero."")*
 
 When your hero is dealt damage, destroy Bloodspill Invocation."		Runeblade Action – Aura	Wírawan Pranoto																	S – 1HP292 – N, S – ARC107 – F, R – ARC107 – F – AT, S R – ARC107 – U	https://storage.googleapis.com/fabmaster/media/images/1HP292.width-450.png – 1HP292 – N, https://storage.googleapis.com/fabmaster/cardfaces/2020-ARC/ARC107.png - ARC107 – F, https://storage.googleapis.com/fabmaster/cardfaces/2020-ARC/ARC107-RF.png - ARC107 – F – AT, https://storage.googleapis.com/fabmaster/cardfaces/2020-U-ARC/U-ARC107.png – ARC107 – U			
 1HP293, ARC108	1HP, ARC	Bloodspill Invocation	3	1		2			C, C	Runeblade, Action, Aura	Go again				"*(Aura's stay in the arena until they are destroyed.)*
 
 **Go again**
 
-When an attack action card you control hits, destroy Bloodspill Invocation then create 3 Runechant tokens. *(They're auras with ""When you play an attack action card or attack with a weapon, destroy Runechant and deal 1 arcane damage to target opposing hero."")*
+When an attack action card you control hits, destroy Bloodspill Invocation then create a Runechant token. *(It's an aura with ""When you play an attack action card or attack with a weapon, destroy Runechant and deal 1 arcane damage to target opposing hero."")*
 
 When your hero is dealt damage, destroy Bloodspill Invocation."		Runeblade Action – Aura	Wírawan Pranoto																	S – 1HP293 – N, S – ARC108 – F, R – ARC108 – F – AT, S R – ARC108 – U	https://storage.googleapis.com/fabmaster/media/images/1HP293.width-450.png – 1HP293 – N, https://storage.googleapis.com/fabmaster/cardfaces/2020-ARC/ARC108.png - ARC108 – F, https://storage.googleapis.com/fabmaster/cardfaces/2020-ARC/ARC108-RF.png – ARC108 – F – AT, https://storage.googleapis.com/fabmaster/cardfaces/2020-U-ARC/U-ARC108.png – ARC108 – U			
 1HP294, ARC109	1HP, ARC	Read the Runes	1	0		2			C, C	Runeblade, Action					"Create 3 Runechant tokens. *(They're auras with ""When you play an attack action card or attack with a weapon, destroy Runechant and deal 1 arcane damage to target opposing hero."")*"		Runeblade Action	Maxim Kostin																	S – 1HP294 – N, S – ARC109 – F, R – ARC109 – F – AT, S R – ARC109 – U	https://storage.googleapis.com/fabmaster/media/images/1HP294.width-450.png – 1HP294 – N, https://storage.googleapis.com/fabmaster/cardfaces/2020-ARC/ARC109.png - ARC109 – F, https://storage.googleapis.com/fabmaster/cardfaces/2020-ARC/ARC109-RF.png - ARC109 – F – AT, https://storage.googleapis.com/fabmaster/cardfaces/2020-U-ARC/U-ARC109.png – ARC109 – U			


### PR DESCRIPTION
The card incorrectly had all three versions producing 3 runechants, instead of 3/2/1 for red/yellow/blue.