### PR TITLE
Make the helper-scripts actually return an exit code if they fail

### DIFF
--- a/helper-scripts/generate-artists.sh
+++ b/helper-scripts/generate-artists.sh
@@ -2,4 +2,3 @@
 
 cd ./generate-artists
 pyenv exec poetry run python main.py
-cd ..

--- a/helper-scripts/generate-htmls.sh
+++ b/helper-scripts/generate-htmls.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 cd ./generate-csv-htmls
-./generate.sh
+./generate.sh || exit $?
 cd ..
 
 echo ""
 
 cd ./generate-json-schema-htmls
-./generate.sh
+./generate.sh || exit $?
 cd ..

--- a/helper-scripts/generate-json.sh
+++ b/helper-scripts/generate-json.sh
@@ -2,4 +2,3 @@
 
 cd ./generate-json
 pyenv exec poetry run python main.py
-cd ..

--- a/helper-scripts/generate-unique-ids.sh
+++ b/helper-scripts/generate-unique-ids.sh
@@ -2,4 +2,3 @@
 
 cd ./generate-unique-ids
 npm run start
-cd ..

--- a/helper-scripts/validate-json.sh
+++ b/helper-scripts/validate-json.sh
@@ -2,4 +2,3 @@
 
 cd ./json-validation
 ./validate-json.sh
-cd ..


### PR DESCRIPTION
This was needed because otherwise they return zero (usually because of `cd ..` which will hardly ever fail) and so any errors will be masked during the pre-commit process.

Resolves #209