### PR TITLE
Fix validate-references for renamed Art Variations column

### DIFF
--- a/documentation/csv-schemas.md
+++ b/documentation/csv-schemas.md
@@ -57,7 +57,7 @@ Note: Cards in are organized by what main set they were initially released in in
 | Rarity | string | The rarity for this card printing. | C |
 | Expansion Slot | bool | Whether the card printing comes in the expansion slot or not | Yes |
 | Foiling | string | The foiling for this card printing. | R |
-| Art Variation | string | The art variation (if any) of this card printing. The [Collector's Center](https://fabtcg.com/collectors-centre/) has good resources for finding details on this. | AA |
+| Art Variations | string | The art variation(s) (if any) of this card printing, comma separated. The [Collector's Center](https://fabtcg.com/collectors-centre/) has good resources for finding details on this. | AA, AB |
 | Artists | string[] | A list of artists for this card printing. | Agri Karuniawan |
 | Flavor Text | string | The flavor text (if any) that appears on this card printing. Do not use italics on this, text is assumed to be in italics. (Example pulled from Talisman of Warfare.) | It's said that wherever the Dracai of War planted this talisman, the lava was soon to flow. |
 | Image URL | string | Link to the image of the card printing from fabtcg.com's [image galleries](https://fabtcg.com/resources/card-galleries/). | https://storage.googleapis.com/fabmaster/media/images/ELE146.width-450.png |

--- a/helper-scripts/validate-references/main.py
+++ b/helper-scripts/validate-references/main.py
@@ -127,7 +127,7 @@ with open(card_printing_filename, newline='') as csvfile:
     for row in reader:
         # TODO: Duplicate Unique ID
 
-        card_printing_summary = f"{row['Card ID']} (Edition: {row['Edition']} - Foiling: {row['Foiling']} - Art Variation: {row['Art Variation']})"
+        card_printing_summary = f"{row['Card ID']} (Edition: {row['Edition']} - Foiling: {row['Foiling']} - Art Variations: {row['Art Variations']})"
 
         # Set Printing Unique ID
         set_printing_unique_id = row['Set Printing Unique ID']
@@ -163,12 +163,14 @@ with open(card_printing_filename, newline='') as csvfile:
                         f"range {this_set_printing['Start Card Id']} - {this_set_printing['End Card Id']}.")
                 errors = True
 
-        # Art Variation
-        variation = row['Art Variation']
-        if variation != '' and variation not in allowed_variations:
-            print(f"Warning: unrecognized variation {variation} in {card_printing_filename} entry for "
-                  f"{card_printing_summary}. Check your spelling or add this to {variation_filename}.")
-            errors = True
+        # Art Variations
+        variations = row['Art Variations']
+        if variations != '':
+            for variation in re.split(',\s*', variations):
+                if variation not in allowed_variations:
+                    print(f"Warning: unrecognized variation {variation} in {card_printing_filename} entry for "
+                          f"{card_printing_summary}. Check your spelling or add this to {variation_filename}.")
+                    errors = True
 
         # Edition
         edition = row['Edition']


### PR DESCRIPTION
Fixes #545

Line 167 splits on comma, since the column now holds lists like `AA, AB, AT`.

Safe to merge on its own: with #544 outstanding the wrapper still reports success, so this can't halt anyone's commit. It does surface 16 pre-existing type/foiling warnings that were previously unreachable.