### PR TITLE
Propagate Python exit codes from helper script wrappers

### DIFF
--- a/helper-scripts/clean-csvs.sh
+++ b/helper-scripts/clean-csvs.sh
@@ -5,8 +5,8 @@
 cd ./clean-csvs
 
 if type pyenv >/dev/null 2>&1; then
-    pyenv exec poetry run python main.py
+    pyenv exec poetry run python main.py || exit $?
 else
-    python main.py
+    python main.py || exit $?
 fi
 cd ..

--- a/helper-scripts/generate-json.sh
+++ b/helper-scripts/generate-json.sh
@@ -5,8 +5,8 @@
 cd ./generate-json
 
 if type pyenv >/dev/null 2>&1; then
-    pyenv exec poetry run python main.py
+    pyenv exec poetry run python main.py || exit $?
 else
-    python main.py
+    python main.py || exit $?
 fi
 cd ..

--- a/helper-scripts/validate-references.sh
+++ b/helper-scripts/validate-references.sh
@@ -5,8 +5,8 @@
 cd ./validate-references
 
 if type pyenv >/dev/null 2>&1; then
-    pyenv exec poetry run python main.py
+    pyenv exec poetry run python main.py || exit $?
 else
-    python main.py
+    python main.py || exit $?
 fi
 cd ..


### PR DESCRIPTION
Fixes #544

Before merging: this makes `pre-commit` start failing on problems that are currently silent. Two things need to land first.

The `validate-references` crash (#545), which #546 fixes.

Then the 16 warnings on `develop`, which come down to three causes:

11 of them: `type.csv` is missing `Puffin`, `Scurv`, `Arakni`, `Companion`, `Log`, `Scroll` and `Disease`. The card rows match the printed type lines (Polly Cranka is `Puffin Companion - Off-Hand Ally`, Pile Driver is `Guardian Weapon - Log (2H)`). `Disease` is the exception, since no printed card carries it yet.

1 of them: `Marked` has an empty `Types` cell, which matches the card, as it has no type line. `re.split(',\s*', '')` returns `['']` and fails the membership check. The Art Variations check guards this case; the Types check doesn't.

5 of them: SUP239-243 have an empty `Foiling`. Every other printing of those five tokens is `S`.

Happy to close this if those are known and intentional.